### PR TITLE
feat: 댓글 생성 기능 구현

### DIFF
--- a/src/main/java/com/votalks/api/controller/CommentController.java
+++ b/src/main/java/com/votalks/api/controller/CommentController.java
@@ -1,0 +1,25 @@
+package com.votalks.api.controller;
+
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.votalks.api.dto.comment.CommentCreateDto;
+import com.votalks.api.service.CommentService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/comments/{id}")
+@RequiredArgsConstructor
+public class CommentController {
+	private final CommentService commentService;
+
+	@PostMapping
+	public void create(@RequestBody @Valid CommentCreateDto dto, @PathVariable Long id) {
+		commentService.create(dto, id);
+	}
+}

--- a/src/main/java/com/votalks/api/dto/comment/CommentCreateDto.java
+++ b/src/main/java/com/votalks/api/dto/comment/CommentCreateDto.java
@@ -1,0 +1,10 @@
+package com.votalks.api.dto.comment;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CommentCreateDto(
+	@NotBlank
+	String content,
+	String uuid
+) {
+}

--- a/src/main/java/com/votalks/api/persistence/entity/Comment.java
+++ b/src/main/java/com/votalks/api/persistence/entity/Comment.java
@@ -67,7 +67,6 @@ public class Comment {
 	private Comment(
 		String content,
 		int userNumber,
-		LocalDateTime createdAt,
 		Vote vote,
 		Uuid uuid,
 		Comment comment,
@@ -75,7 +74,6 @@ public class Comment {
 	) {
 		this.content = content;
 		this.userNumber = userNumber;
-		this.createdAt = createdAt;
 		this.vote = vote;
 		this.uuid = uuid;
 		this.comment = comment;

--- a/src/main/java/com/votalks/api/persistence/entity/Comment.java
+++ b/src/main/java/com/votalks/api/persistence/entity/Comment.java
@@ -4,8 +4,11 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import com.votalks.api.dto.comment.CommentCreateDto;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -19,6 +22,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -35,6 +39,10 @@ public class Comment {
 
 	@Column(name = "content", length = 50, nullable = false)
 	private String content;
+
+	@Column(name = "user_number")
+	@ColumnDefault("0")
+	private int userNumber;
 
 	@CreatedDate
 	@Column(name = "create_at", nullable = false, updatable = false)
@@ -54,4 +62,37 @@ public class Comment {
 
 	@OneToMany(mappedBy = "comment", orphanRemoval = true)
 	private List<Comment> reply = new ArrayList<>();
+
+	@Builder
+	private Comment(
+		String content,
+		int userNumber,
+		LocalDateTime createdAt,
+		Vote vote,
+		Uuid uuid,
+		Comment comment,
+		List<Comment> reply
+	) {
+		this.content = content;
+		this.userNumber = userNumber;
+		this.createdAt = createdAt;
+		this.vote = vote;
+		this.uuid = uuid;
+		this.comment = comment;
+		this.reply = reply;
+	}
+
+	public static Comment create(
+		CommentCreateDto dto,
+		Uuid uuid,
+		Vote vote,
+		int userNumber
+	) {
+		return Comment.builder()
+			.content(dto.content())
+			.uuid(uuid)
+			.userNumber(userNumber)
+			.vote(vote)
+			.build();
+	}
 }

--- a/src/main/java/com/votalks/api/persistence/entity/Comment.java
+++ b/src/main/java/com/votalks/api/persistence/entity/Comment.java
@@ -28,7 +28,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "comment")
+@Table(name = "tbl_comment")
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Comment {

--- a/src/main/java/com/votalks/api/persistence/entity/Like.java
+++ b/src/main/java/com/votalks/api/persistence/entity/Like.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "comment")
+@Table(name = "likes")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Like {
 	@Id

--- a/src/main/java/com/votalks/api/persistence/entity/Like.java
+++ b/src/main/java/com/votalks/api/persistence/entity/Like.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "likes")
+@Table(name = "tbl_like")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Like {
 	@Id

--- a/src/main/java/com/votalks/api/persistence/entity/Uuid.java
+++ b/src/main/java/com/votalks/api/persistence/entity/Uuid.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "uuid")
+@Table(name = "tbl_uuid")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Uuid {
 	@Id

--- a/src/main/java/com/votalks/api/persistence/entity/UuidLike.java
+++ b/src/main/java/com/votalks/api/persistence/entity/UuidLike.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "uuid_likes")
+@Table(name = "tbl_uuid_like")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UuidLike {
 	@Id

--- a/src/main/java/com/votalks/api/persistence/entity/UuidLike.java
+++ b/src/main/java/com/votalks/api/persistence/entity/UuidLike.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "uuid_like")
+@Table(name = "uuid_likes")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UuidLike {
 	@Id

--- a/src/main/java/com/votalks/api/persistence/entity/UuidVoteOption.java
+++ b/src/main/java/com/votalks/api/persistence/entity/UuidVoteOption.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "uuid_vote_option")
+@Table(name = "tbl_uuid_vote_option")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UuidVoteOption {
 	@Id

--- a/src/main/java/com/votalks/api/persistence/entity/Vote.java
+++ b/src/main/java/com/votalks/api/persistence/entity/Vote.java
@@ -63,14 +63,12 @@ public class Vote {
 	private Vote(
 		String title,
 		String description,
-		LocalDateTime createdAt,
 		int selectCount,
 		Category category,
 		Uuid uuid
 	) {
 		this.title = title;
 		this.description = description;
-		this.createdAt = createdAt;
 		this.selectCount = selectCount;
 		this.category = category;
 		this.uuid = uuid;

--- a/src/main/java/com/votalks/api/persistence/entity/Vote.java
+++ b/src/main/java/com/votalks/api/persistence/entity/Vote.java
@@ -29,7 +29,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "vote")
+@Table(name = "tbl_vote")
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Vote {

--- a/src/main/java/com/votalks/api/persistence/entity/VoteOption.java
+++ b/src/main/java/com/votalks/api/persistence/entity/VoteOption.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "vote_option")
+@Table(name = "tbl_vote_option")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class VoteOption {
 	@Id

--- a/src/main/java/com/votalks/api/persistence/repository/CommentRepository.java
+++ b/src/main/java/com/votalks/api/persistence/repository/CommentRepository.java
@@ -1,10 +1,23 @@
 package com.votalks.api.persistence.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.votalks.api.persistence.entity.Comment;
+import com.votalks.api.persistence.entity.Uuid;
 import com.votalks.api.persistence.entity.Vote;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 	int countByVote(Vote vote);
+
+	boolean existsByVoteAndUuid(Vote vote, Uuid uuid);
+
+	@Query("SELECT c.userNumber FROM Comment c WHERE c.uuid = :uuid")
+	int findUserNumberByUuid(@Param("uuid") Uuid uuid);
+
+	@Query("SELECT MAX(c.userNumber) FROM Comment c WHERE c.vote = :vote")
+	Optional<Integer> findMaxUserNumberByVote(@Param("vote") Vote vote);
 }

--- a/src/main/java/com/votalks/api/service/CommentService.java
+++ b/src/main/java/com/votalks/api/service/CommentService.java
@@ -1,0 +1,62 @@
+package com.votalks.api.service;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
+import com.votalks.api.dto.comment.CommentCreateDto;
+import com.votalks.api.persistence.entity.Comment;
+import com.votalks.api.persistence.entity.Uuid;
+import com.votalks.api.persistence.entity.Vote;
+import com.votalks.api.persistence.repository.CommentRepository;
+import com.votalks.api.persistence.repository.UuidRepository;
+import com.votalks.api.persistence.repository.VoteRepository;
+import com.votalks.global.error.exception.NotFoundException;
+import com.votalks.global.error.model.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+	private final CommentRepository commentRepository;
+	private final VoteRepository voteRepository;
+	private final UuidRepository uuidRepository;
+
+	public void create(CommentCreateDto dto, Long id) {
+		final Vote vote = voteRepository.findById(id)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_NOT_VOTE_FOUND));
+		final Uuid uuid = getOrCreate(dto.uuid());
+
+		if (!authorOrExists(dto, vote, uuid)) {
+			final int userNumber = commentRepository.findMaxUserNumberByVote(vote)
+				.orElse(0) + 1;
+
+			commentRepository.save(Comment.create(dto, uuid, vote, userNumber));
+		}
+	}
+
+	private boolean authorOrExists(CommentCreateDto dto, Vote vote, Uuid uuid) {
+		if (vote.getUuid().equals(uuid)) {
+			final Comment comment = Comment.create(dto, uuid, vote, 0);
+			commentRepository.save(comment);
+			return true;
+		}
+
+		if (commentRepository.existsByVoteAndUuid(vote, uuid)) {
+			final int userNumber = commentRepository.findUserNumberByUuid(uuid);
+			final Comment comment = Comment.create(dto, uuid, vote, userNumber);
+			commentRepository.save(comment);
+			return true;
+		}
+		return false;
+	}
+
+	private Uuid getOrCreate(String uuid) {
+		if (uuid == null) {
+			return uuidRepository.save(Uuid.create(UUID.randomUUID()));
+		}
+		return uuidRepository.findById(Uuid.fromString(uuid))
+			.orElseGet(() -> uuidRepository.save(Uuid.create(UUID.randomUUID())));
+	}
+}

--- a/src/main/java/com/votalks/api/service/CommentService.java
+++ b/src/main/java/com/votalks/api/service/CommentService.java
@@ -53,7 +53,7 @@ public class CommentService {
 	}
 
 	private Uuid getOrCreate(String uuid) {
-		if (uuid == null) {
+		if (uuid == null || uuid.length() != 32) {
 			return uuidRepository.save(Uuid.create(UUID.randomUUID()));
 		}
 		return uuidRepository.findById(Uuid.fromString(uuid))

--- a/src/main/java/com/votalks/api/service/CommentService.java
+++ b/src/main/java/com/votalks/api/service/CommentService.java
@@ -2,6 +2,7 @@ package com.votalks.api.service;
 
 import java.util.UUID;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 
 import com.votalks.api.dto.comment.CommentCreateDto;
@@ -27,33 +28,22 @@ public class CommentService {
 		final Vote vote = voteRepository.findById(id)
 			.orElseThrow(() -> new NotFoundException(ErrorCode.FAIL_NOT_VOTE_FOUND));
 		final Uuid uuid = getOrCreate(dto.uuid());
-
-		if (!authorOrExists(dto, vote, uuid)) {
-			final int userNumber = commentRepository.findMaxUserNumberByVote(vote)
-				.orElse(0) + 1;
-
-			commentRepository.save(Comment.create(dto, uuid, vote, userNumber));
-		}
+		final int userNumber = determineUserNumber(vote, uuid);
+		commentRepository.save(Comment.create(dto, uuid, vote, userNumber));
 	}
 
-	private boolean authorOrExists(CommentCreateDto dto, Vote vote, Uuid uuid) {
+	private int determineUserNumber(Vote vote, Uuid uuid) {
 		if (vote.getUuid().equals(uuid)) {
-			final Comment comment = Comment.create(dto, uuid, vote, 0);
-			commentRepository.save(comment);
-			return true;
+			return 0;
 		}
-
 		if (commentRepository.existsByVoteAndUuid(vote, uuid)) {
-			final int userNumber = commentRepository.findUserNumberByUuid(uuid);
-			final Comment comment = Comment.create(dto, uuid, vote, userNumber);
-			commentRepository.save(comment);
-			return true;
+			return commentRepository.findUserNumberByUuid(uuid);
 		}
-		return false;
+		return commentRepository.findMaxUserNumberByVote(vote).orElse(0) + 1;
 	}
 
 	private Uuid getOrCreate(String uuid) {
-		if (uuid == null || uuid.length() != 32) {
+		if (StringUtils.isEmpty(uuid) || uuid.length() != 32) {
 			return uuidRepository.save(Uuid.create(UUID.randomUUID()));
 		}
 		return uuidRepository.findById(Uuid.fromString(uuid))

--- a/src/main/java/com/votalks/api/service/VoteService.java
+++ b/src/main/java/com/votalks/api/service/VoteService.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -132,7 +133,7 @@ public class VoteService {
 	}
 
 	private Uuid getOrCreate(String uuid) {
-		if (uuid == null || uuid.length() != 32) {
+		if (StringUtils.isEmpty(uuid) || uuid.length() != 32) {
 			return uuidRepository.save(Uuid.create(UUID.randomUUID()));
 		}
 		return uuidRepository.findById(Uuid.fromString(uuid))

--- a/src/main/java/com/votalks/api/service/VoteService.java
+++ b/src/main/java/com/votalks/api/service/VoteService.java
@@ -132,7 +132,7 @@ public class VoteService {
 	}
 
 	private Uuid getOrCreate(String uuid) {
-		if (uuid == null) {
+		if (uuid == null || uuid.length() != 32) {
 			return uuidRepository.save(Uuid.create(UUID.randomUUID()));
 		}
 		return uuidRepository.findById(Uuid.fromString(uuid))

--- a/src/test/java/com/votalks/api/controller/CommentControllerTest.java
+++ b/src/test/java/com/votalks/api/controller/CommentControllerTest.java
@@ -1,0 +1,84 @@
+package com.votalks.api.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.votalks.api.dto.comment.CommentCreateDto;
+import com.votalks.api.dto.vote.VoteCreateDto;
+import com.votalks.api.persistence.entity.Vote;
+import com.votalks.api.persistence.entity.VoteOption;
+import com.votalks.api.persistence.repository.CommentRepository;
+import com.votalks.api.persistence.repository.UuidRepository;
+import com.votalks.api.persistence.repository.UuidVoteOptionRepository;
+import com.votalks.api.persistence.repository.VoteOptionRepository;
+import com.votalks.api.persistence.repository.VoteRepository;
+import com.votalks.api.service.CommentService;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class CommentControllerTest {
+	@Autowired
+	MockMvc mockMvc;
+
+	@Autowired
+	ObjectMapper objectMapper;
+
+	@Autowired
+	UuidRepository uuidRepository;
+
+	@Autowired
+	UuidVoteOptionRepository uuidVoteOptionRepository;
+
+	@Autowired
+	VoteRepository voteRepository;
+
+	@Autowired
+	VoteOptionRepository voteOptionRepository;
+
+	@Autowired
+	CommentRepository commentRepository;
+
+	@MockBean
+	CommentService commentService;
+
+	@BeforeEach
+	void setUp() {
+		VoteCreateDto voteCreateDto = new VoteCreateDto(null, "테스트입니다.", "DEV", "테스트입니다", Arrays.asList("1번", "2번"), 2);
+
+		Vote vote = Vote.create(voteCreateDto, null);
+		vote = voteRepository.save(vote);
+
+		Vote finalVote = vote;
+		List<VoteOption> voteOptions = voteCreateDto.voteOptions()
+			.stream()
+			.map(optionValue -> VoteOption.create(optionValue, finalVote))
+			.collect(Collectors.toList());
+
+		voteOptionRepository.saveAll(voteOptions);
+	}
+
+	@Test
+	@DisplayName("POST - 댓글을 성공적으로 생성한다. - void")
+	void create_vote_success() throws Exception {
+		CommentCreateDto commentCreateDto = new CommentCreateDto("테스트", null);
+
+		// When & Then
+		this.mockMvc.perform(post("/api/v1/comments/" + 1L).contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(commentCreateDto))).andExpect(status().isOk());
+	}
+}


### PR DESCRIPTION
UUID의 경우 String으로 크기가 20보다 작거나, 32보다 크면 Uuid의 객체를 찾는 과정에서 예외가 발생하는 것을 발견했습니다.
따라서 Uuid가 32자가 아니거나, null이면 바로 새로 발급해 주는 걸로 변경하였습니다.
데이터베이스에는 Uuid를 패턴을 사용해 전부 32자가 들어오는 것을 확인했습니다.