### PR TITLE
feat: 댓글 조회 시 사용자의 좋아요 누른 상태를 보여준다. 

### DIFF
--- a/src/main/java/com/votalks/api/controller/CommentController.java
+++ b/src/main/java/com/votalks/api/controller/CommentController.java
@@ -39,7 +39,10 @@ public class CommentController {
 	public Page<CommentReadDto> read(
 		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "10") int size,
-		@PathVariable(name = "vote-id") Long id) {
-		return commentService.read(id, page, size);
+		@PathVariable(name = "vote-id") Long id,
+		HttpServletRequest request,
+		HttpServletResponse response
+	) {
+		return commentService.read(id, page, size, request, response);
 	}
 }

--- a/src/main/java/com/votalks/api/controller/VoteController.java
+++ b/src/main/java/com/votalks/api/controller/VoteController.java
@@ -1,7 +1,10 @@
 package com.votalks.api.controller;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -11,7 +14,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.votalks.api.dto.vote.VoteCreateDto;
+import com.votalks.api.dto.vote.VoteOptionWithCountDto;
 import com.votalks.api.dto.vote.VoteReadDto;
+import com.votalks.api.dto.vote.VoteResponse;
 import com.votalks.api.dto.vote.VoteTakeDto;
 import com.votalks.api.service.VoteService;
 
@@ -36,26 +41,50 @@ public class VoteController {
 	}
 
 	@PostMapping("/{vote-id}")
-	public HttpHeaders select(
+	public ResponseEntity<List<VoteOptionWithCountDto>> select(
 		@RequestBody @Valid VoteTakeDto dto,
 		@PathVariable(name = "vote-id") Long id,
 		HttpServletRequest request,
 		HttpServletResponse response
 	) {
-		return voteService.select(dto, id, request, response);
+		VoteResponse<List<VoteOptionWithCountDto>> voteResponse = voteService.select(dto, id, request, response);
+		HttpHeaders headers = voteResponse.httpHeaders();
+		List<VoteOptionWithCountDto> voteData = voteResponse.data();
+
+		return ResponseEntity.ok()
+			.headers(headers)
+			.body(voteData);
 	}
 
 	@GetMapping("/{vote-id}")
-	public VoteReadDto read(@PathVariable(name = "vote-id") Long id) {
-		return voteService.read(id);
+	public ResponseEntity<VoteReadDto> read(
+		@PathVariable(name = "vote-id") Long id,
+		HttpServletRequest request,
+		HttpServletResponse response
+	) {
+		VoteResponse<VoteReadDto> voteResponse = voteService.read(id, request, response);
+		HttpHeaders headers = voteResponse.httpHeaders();
+		VoteReadDto voteData = voteResponse.data();
+
+		return ResponseEntity.ok()
+			.headers(headers)
+			.body(voteData);
 	}
 
 	@GetMapping
-	public Page<VoteReadDto> readAll(
+	public ResponseEntity<Page<VoteReadDto>> readAll(
 		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "10") int size,
-		@RequestParam(required = false) String category
+		@RequestParam(required = false) String category,
+		HttpServletRequest request,
+		HttpServletResponse response
 	) {
-		return voteService.readAll(page, size, category);
+		VoteResponse<Page<VoteReadDto>> voteResponse = voteService.readAll(page, size, category, request, response);
+		HttpHeaders headers = voteResponse.httpHeaders();
+		Page<VoteReadDto> voteData = voteResponse.data();
+
+		return ResponseEntity.ok()
+			.headers(headers)
+			.body(voteData);
 	}
 }

--- a/src/main/java/com/votalks/api/dto/comment/CommentReadDto.java
+++ b/src/main/java/com/votalks/api/dto/comment/CommentReadDto.java
@@ -11,6 +11,7 @@ public record CommentReadDto(
 	LocalDateTime createAt,
 	int likeCount,
 	int dislikeCount,
-	int totalReplyCount
+	int totalReplyCount,
+	String likeType
 ) {
 }

--- a/src/main/java/com/votalks/api/dto/vote/VoteOptionWithCountDto.java
+++ b/src/main/java/com/votalks/api/dto/vote/VoteOptionWithCountDto.java
@@ -1,8 +1,12 @@
 package com.votalks.api.dto.vote;
 
+import lombok.Builder;
+
+@Builder
 public record VoteOptionWithCountDto(
 	Long id,
 	String title,
-	int count
+	int count,
+	boolean isCheck
 ) {
 }

--- a/src/main/java/com/votalks/api/dto/vote/VoteResponse.java
+++ b/src/main/java/com/votalks/api/dto/vote/VoteResponse.java
@@ -1,0 +1,12 @@
+package com.votalks.api.dto.vote;
+
+import org.springframework.http.HttpHeaders;
+
+import lombok.Builder;
+
+@Builder
+public record VoteResponse<T>(
+	HttpHeaders httpHeaders,
+	T data
+) {
+}

--- a/src/main/java/com/votalks/api/persistence/entity/Comment.java
+++ b/src/main/java/com/votalks/api/persistence/entity/Comment.java
@@ -104,7 +104,7 @@ public class Comment {
 			.build();
 	}
 
-	public static CommentReadDto toCommentReadDto(Comment comment) {
+	public static CommentReadDto toCommentReadDto(Comment comment, String likeType) {
 		return CommentReadDto.builder()
 			.userNumber(comment.getUserNumber())
 			.content(comment.getContent())
@@ -112,6 +112,7 @@ public class Comment {
 			.createAt(comment.getCreatedAt())
 			.dislikeCount(comment.getLike().getDislikeCount())
 			.totalReplyCount(comment.getReply().size())
+			.likeType(likeType)
 			.build();
 	}
 }

--- a/src/main/java/com/votalks/api/persistence/entity/LikeType.java
+++ b/src/main/java/com/votalks/api/persistence/entity/LikeType.java
@@ -12,7 +12,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum LikeType {
-	CREATE("생성", "create"),
+	NONE("없음", "none"),
 	LIKE("좋아요", "like"),
 	DISLIKE("싫어요", "dislike");
 	private final String name;

--- a/src/main/java/com/votalks/api/persistence/entity/VoteOption.java
+++ b/src/main/java/com/votalks/api/persistence/entity/VoteOption.java
@@ -1,5 +1,7 @@
 package com.votalks.api.persistence.entity;
 
+import com.votalks.api.dto.vote.VoteOptionWithCountDto;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -44,6 +46,25 @@ public class VoteOption {
 
 	public void select() {
 		this.voteCount++;
+	}
+
+	public VoteOptionWithCountDto read(Long id) {
+		boolean check = id.equals(this.getId());
+		return VoteOptionWithCountDto.builder()
+			.id(this.id)
+			.title(this.content)
+			.count(this.voteCount)
+			.isCheck(check)
+			.build();
+	}
+
+	public VoteOptionWithCountDto read(boolean isSelected) {
+		return VoteOptionWithCountDto.builder()
+			.id(this.id)
+			.title(this.content)
+			.count(this.voteCount)
+			.isCheck(isSelected)
+			.build();
 	}
 }
 

--- a/src/main/java/com/votalks/api/persistence/repository/UuidLikeRepository.java
+++ b/src/main/java/com/votalks/api/persistence/repository/UuidLikeRepository.java
@@ -1,5 +1,6 @@
 package com.votalks.api.persistence.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,8 +10,17 @@ import org.springframework.data.repository.query.Param;
 import com.votalks.api.persistence.entity.Like;
 import com.votalks.api.persistence.entity.Uuid;
 import com.votalks.api.persistence.entity.UuidLike;
+import com.votalks.api.persistence.entity.Vote;
 
 public interface UuidLikeRepository extends JpaRepository<UuidLike, Long> {
 	@Query("SELECT ul FROM UuidLike ul WHERE ul.uuid = :uuid AND ul.like = :like")
 	Optional<UuidLike> findByUuidAndLike(@Param("uuid") Uuid uuid, @Param("like") Like like);
+
+	/**
+	 * 댓글에 있는 like와, uuidLike에 있는 like가 일치하고, 투표에 속해있는 댓글이어야 하며, uuid가 일치한 uuidLike를 가져온다.
+	 */
+	@Query("SELECT ul FROM UuidLike ul JOIN Comment c ON ul.like.id = c.like.id WHERE c.vote = :vote AND ul.uuid = :uuid")
+	List<UuidLike> findByUuidAndVote(Uuid uuid, Vote vote);
+
+	List<UuidLike> findByUuid(Uuid uuid);
 }

--- a/src/main/java/com/votalks/api/persistence/repository/UuidVoteOptionRepository.java
+++ b/src/main/java/com/votalks/api/persistence/repository/UuidVoteOptionRepository.java
@@ -1,10 +1,20 @@
 package com.votalks.api.persistence.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.votalks.api.persistence.entity.Uuid;
 import com.votalks.api.persistence.entity.UuidVoteOption;
+import com.votalks.api.persistence.entity.Vote;
+import com.votalks.api.persistence.entity.VoteOption;
 
 public interface UuidVoteOptionRepository extends JpaRepository<UuidVoteOption, Long> {
-	boolean existsByUuid(Uuid uuid);
+	boolean existsByUuidAndVoteOption(Uuid uuid, VoteOption voteOption);
+
+	//voteOption에 연결된 vote와 uuid를 통해 voteOption 찾기.
+	@Query("SELECT uvo.voteOption FROM UuidVoteOption uvo WHERE uvo.uuid = :uuid AND uvo.voteOption.vote = :vote")
+	List<VoteOption> findAllVoteOptionsByUuidAndVoteId(@Param("uuid") Uuid uuid, @Param("vote") Vote vote);
 }

--- a/src/main/java/com/votalks/api/persistence/repository/VoteOptionRepository.java
+++ b/src/main/java/com/votalks/api/persistence/repository/VoteOptionRepository.java
@@ -12,4 +12,6 @@ public interface VoteOptionRepository extends JpaRepository<VoteOption, Long> {
 	List<VoteOption> findAllByVote(Vote vote);
 
 	Optional<VoteOption> findByIdAndVote_Id(Long id, Long voteOptionId);
+
+	List<VoteOption> findAllByVote_Id(Long id);
 }


### PR DESCRIPTION
UuidLikeRepisitory에 있는 쿼리문을 중점으로 봐주시면 감사하겠습니다.

<처음 로직>
처음 로직은 findByUuid로써, 해당 사용자가 가지고 있는 모든 uuidLike를 가져왔습니다.
너무 비효율적이라 생각했고 쿼리를 다시 짰습니다.

<개선 로직> (조인)
하나의 투표가 가지고 있는 댓글들 중에서, uuidLike에 like와 comment에 like와 일치하며, 입력받은 uuid와 uuidLike에 uuid와 일치해야 한다. 